### PR TITLE
Add Checkouts tab showing local git repos with PR status

### DIFF
--- a/ai-status.js
+++ b/ai-status.js
@@ -1,7 +1,8 @@
-import { runCmd, CHAOS, CMD_TIMEOUT, setCmdLogHook } from './helpers.js';
+import { runCmd, gh, daysSince, CHAOS, CMD_TIMEOUT, setCmdLogHook } from './helpers.js';
 import { homedir } from 'node:os';
 import { readCacheEntry, writeCacheEntry, hashPrompt, cleanAiCache } from './ai-cache.js';
 import { fetchIssueDetails, fetchPRSummary, fetchPRPromptData, fetchRecentComments } from './github-api.js';
+import { checkDivergence } from './repo-scan.js';
 import { cleanChatPrompts } from './launch-chat.js';
 
 // === Timeline / Context / Prompt Builders ===
@@ -344,6 +345,40 @@ export function handleAIStream(req, res, { allItems, ghUsername, ghVersion, clau
     const pr = allPRs[index];
     if (pr.fetchError) return;
 
+    // Checkout items: fetch real remote HEAD + discover PR for this branch
+    if (pr.section === 'checkout') {
+      if (pr._checkoutSkipAI) return; // default branch, no PR possible
+      // Refine diverge status with real remote HEAD from GitHub API
+      const remoteHeadSha = await gh('api', `repos/${pr.repo}/branches/${pr._checkoutBranch}`, '--jq', '.commit.sha',
+        { __reason: `remote HEAD: ${pr.repo}#${pr._checkoutBranch}` }, signal).then(s => s.trim() || null, () => null);
+      if (remoteHeadSha) {
+        const localHead = (await runCmd('git', ['rev-parse', 'HEAD'], { cwd: pr._checkoutPath, reason: 'local HEAD' }).catch(() => '')).trim();
+        if (localHead === remoteHeadSha) {
+          pr._checkoutDivergeStatus = 'synced';
+        } else if (localHead) {
+          pr._checkoutDivergeStatus = await checkDivergence(pr._checkoutPath, localHead, remoteHeadSha) || 'unsynced';
+        }
+      }
+      // Discover PR for this branch
+      itemPhase[index] = `gh pr list --head ${pr._checkoutBranch}`;
+      sendIfActive(index, 'ai-phase', { index, phase: itemPhase[index] });
+      const raw = await gh('pr', 'list', '--repo', pr.repo, '--head', pr._checkoutBranch, '--state', 'all', '--json', 'number,title,url,state,headRefName,updatedAt', '--limit', '1', { __reason: `checkout PR: ${pr.repo}#${pr._checkoutBranch}` }, signal).catch(() => '[]');
+      const prs = JSON.parse(raw);
+      if (!prs.length) {
+        sendIfActive(index, 'pr-details', { index, branch: pr._checkoutBranch, repoShort: pr.repo.split('/').pop(), failing: [], divergeStatus: pr._checkoutDivergeStatus, dirty: pr._checkoutDirty, changedCount: pr._checkoutChangedFiles });
+        sendIfActive(index, 'ai-done', { index, statusText: 'no PR', statusClass: 'warning' });
+        return;
+      }
+      const found = prs[0];
+      pr.title = found.title;
+      pr.html_url = found.url;
+      pr.number = found.number;
+      pr.state = found.state?.toLowerCase();
+      pr.updated_at = found.updatedAt;
+      pr.days = daysSince(found.updatedAt);
+      pr._checkoutPRDiscovered = true;
+    }
+
     // Lazy-load all details (deferred from Phase 1 for faster table render)
     if (pr.isIssue) {
       itemPhase[index] = `gh issue view ${pr.number} --repo ${pr.repo}`;
@@ -363,7 +398,20 @@ export function handleAIStream(req, res, { allItems, ghUsername, ghVersion, clau
         const s = (c.conclusion || c.state || c.status || '').toUpperCase();
         return s === 'FAILURE' || s === 'ERROR' || s === 'TIMED_OUT';
       });
-      sendIfActive(index, 'pr-details', { index, branch, repoShort, failing });
+      const prDetailsData = { index, branch, repoShort, failing };
+      if (pr._checkoutPRDiscovered) {
+        prDetailsData.prTitle = pr.title;
+        prDetailsData.prUrl = pr.html_url;
+        prDetailsData.prNumber = pr.number;
+        prDetailsData.prState = pr.state;
+        prDetailsData.prDays = pr.days;
+      }
+      if (pr.section === 'checkout') {
+        prDetailsData.divergeStatus = pr._checkoutDivergeStatus;
+        prDetailsData.dirty = pr._checkoutDirty;
+        prDetailsData.changedCount = pr._checkoutChangedFiles;
+      }
+      sendIfActive(index, 'pr-details', prDetailsData);
       if (pr.section === 'mentioned') {
         const myComments = (summary.comments || []).some(c => c.author?.login === ghUsername);
         const myReviews = (summary.reviews || []).some(r => r.author?.login === ghUsername);

--- a/dashboard-html.js
+++ b/dashboard-html.js
@@ -106,7 +106,7 @@ export const INDEX_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
-export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssues, mentionedPRs, commentedPRs, mentionedIssues, commentedIssues, date, updateInfo, { repoColorMap, installedIDEs, period, ghUsername, archivedUrls, autoUnarchivedUrls, unimportantUrls, markedImportantUrls }) {
+export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssues, mentionedPRs, commentedPRs, mentionedIssues, commentedIssues, date, updateInfo, { repoColorMap, installedIDEs, period, ghUsername, archivedUrls, autoUnarchivedUrls, unimportantUrls, markedImportantUrls, checkoutItems }) {
   const archivedSet = new Set(Object.keys(archivedUrls || {}));
   const autoUnarchivedSet = new Set(autoUnarchivedUrls || []);
   const unimportantSet = new Set(Object.keys(unimportantUrls || {}));
@@ -115,22 +115,36 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
     return repoColorMap[repoName] || '#8b949e';
   }
 
-  function stateBadge(state) {
-    if (!state) return '';
-    const colors = { open: '#3fb950', merged: '#a371f7', closed: '#f85149' };
-    const color = colors[state] || '#8b949e';
-    return ` <span class="state-badge" style="color:${color};border-color:${color}">${state}</span>`;
+  const chipPalette = {
+    green:  { color: '#3fb950', bg: '#1a3a1a', border: '#238636' },
+    yellow: { color: '#d29922', bg: '#3d1f00', border: '#9e6a03' },
+    blue:   { color: '#58a6ff', bg: '#0c2d6b', border: '#1f6feb' },
+    red:    { color: '#f85149', bg: '#3d0a0a', border: '#da3633' },
+    purple: { color: '#a371f7', bg: '#271c4d', border: '#8957e5' },
+    muted:  { color: '#484f58', bg: '#161b22', border: '#30363d' },
+    grey:   { color: '#8b949e', bg: '#1c2128', border: '#30363d' },
+  };
+
+  function chip(label, tone, extraClass) {
+    const p = chipPalette[tone] || chipPalette.grey;
+    return ` <span class="chip${extraClass ? ' ' + extraClass : ''}" style="color:${p.color};background:${p.bg};border-color:${p.border}">${label}</span>`;
   }
 
-  function statusCell(item, globalIndex) {
+  function stateBadge(state) {
+    if (!state) return '';
+    const tones = { open: 'green', merged: 'purple', closed: 'red' };
+    return chip(state, tones[state] || 'grey');
+  }
+
+  function statusCell(item, globalIndex, prefillActions) {
     if (item.fetchError) {
       return `<td class="status-col status-bad">Fetch failed: ${escapeHtml(item.fetchError)}</td>`;
     }
     return `<td class="status-col" id="status-${globalIndex}">
                     <span class="status-text">queued...</span>
                     <br>
-                    <span id="inline-actions-${globalIndex}"></span>
-                    ${item.isIssue ? '' : `<span class="action-btn action-btn-accent" onclick="showRepoSelectionDialog(${globalIndex})">pick git clone</span>`}
+                    <span id="inline-actions-${globalIndex}">${prefillActions || ''}</span>
+                    ${item.isIssue || item.section === 'checkout' ? '' : `<span class="action-btn action-btn-accent" onclick="showRepoSelectionDialog(${globalIndex})">checkout</span>`}
                     <span class="copy-prompt" onclick="copyPrompt(${globalIndex})">
                         copy prompt for debugging
                         <div class="prompt-tooltip" id="prompt-tooltip-${globalIndex}"></div>
@@ -146,7 +160,7 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
     const color = repoColor(repoShort);
     return `            <tr>
                 <td class="repo-col" style="color:${color}">${escapeHtml(repoShort)}</td>
-                <td class="title-col">
+                <td class="title-col" id="title-${globalIndex}">
                     <a href="${escapeHtml(pr.html_url)}">#${pr.number} ${escapeHtml(pr.title)}</a>
                     ${authorSpan}${stateSpan}
                 </td>
@@ -221,8 +235,8 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
     const isUnimportant = !isArchived && unimportantSet.has(item.html_url);
     const urlAttr = escapeHtml(item.html_url).replace(/"/g, '&quot;');
     const isMarkedImportant = markedImportantSet.has(item.html_url);
-    const unarchivedBadge = autoUnarchivedSet.has(item.html_url) ? ' <span class="unarchived-badge">unarchived: new comments</span>' : '';
-    const importantBadge = isMarkedImportant ? ' <span class="important-badge">marked as important</span>' : '';
+    const unarchivedBadge = autoUnarchivedSet.has(item.html_url) ? chip('unarchived: new comments', 'yellow', 'unarchived-badge') : '';
+    const importantBadge = isMarkedImportant ? chip('marked as important', 'blue', 'important-badge') : '';
     const hidden = isArchived || isUnimportant;
     const attrs = isArchived ? ' data-archived="1"' : isUnimportant ? ' data-unimportant="1"' : '';
     const miAttr = isMarkedImportant ? ' data-marked-important="1"' : '';
@@ -235,6 +249,36 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
                 ${correspondenceStatusCell(item, globalIndex)}
                 <td class="ci-col"></td>
                 <td class="days-col days-${daysClass(item.days)}">${item.days}d</td>
+            </tr>`;
+  }
+
+  function checkoutActions(item, globalIndex) {
+    let html = `<span class="inline-action" onclick="inlineChat(${globalIndex})">chat</span>`;
+    for (const ide of installedIDEs) {
+      const cmdEsc = escapeHtml(ide.cmd).replace(/'/g, '&#39;');
+      html += `<span class="inline-action" onclick="inlineIDE('${cmdEsc}',${globalIndex})">${escapeHtml(ide.name)}</span>`;
+    }
+    return html;
+  }
+
+  function checkoutRow(item, globalIndex) {
+    const repoShort = item.repo.split('/').pop();
+    const color = repoColor(repoShort);
+    const branchEsc = escapeHtml(item._checkoutBranch || '(detached)');
+    const pathAttr = escapeHtml(item._checkoutPath).replace(/"/g, '&quot;');
+    const skipAI = item._checkoutSkipAI;
+    const actions = checkoutActions(item, globalIndex);
+    return `            <tr data-path="${pathAttr}">
+                <td class="repo-col" style="color:${color}">${escapeHtml(repoShort)}</td>
+                <td class="title-col" id="title-${globalIndex}">
+                    ${escapeHtml(item._checkoutDisplayPath)}
+                </td>
+                <td class="branch-col" id="branch-${globalIndex}"><span class="branch-name" onclick="copyBranch(this)" title="Click to copy">${branchEsc}</span></td>
+                ${skipAI
+                  ? `<td class="status-col" id="status-${globalIndex}" style="font-size:11px;color:#484f58">no PR<br><span id="inline-actions-${globalIndex}">${actions}</span></td>`
+                  : statusCell(item, globalIndex, actions)}
+                <td class="ci-col" id="ci-${globalIndex}"></td>
+                <td class="days-col" id="days-${globalIndex}"></td>
             </tr>`;
   }
 
@@ -252,6 +296,15 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
   const commentedPRRows = commentedPRs.map(pr => correspondenceRow(pr, true, idx++, true)).join('\n');
   const mentionedIssueRows = mentionedIssues.map(i => correspondenceRow(i, false, idx++, false)).join('\n');
   const commentedIssueRows = commentedIssues.map(i => correspondenceRow(i, false, idx++, false)).join('\n');
+  const checkoutStartIdx = idx;
+  const checkoutRows = (checkoutItems || []).map(item => checkoutRow(item, idx++)).join('\n');
+  const checkoutCloneData = JSON.stringify((checkoutItems || []).map((item, i) => ({
+    idx: checkoutStartIdx + i,
+    path: item._checkoutPath,
+    dirty: item._checkoutDirty,
+    changedCount: item._checkoutChangedFiles,
+    divergeStatus: item._checkoutDivergeStatus,
+  })));
 
   const hiddenSet = new Set([...archivedSet, ...unimportantSet]);
   const visibleMentionedPRs = mentionedPRs.filter(pr => !hiddenSet.has(pr.html_url)).length;
@@ -320,9 +373,7 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
         .header-links a { color: #484f58; text-decoration: none; }
         .header-links a:hover { color: #58a6ff; }
 
-        .state-badge { font-size: 10px; border: 1px solid; border-radius: 3px; padding: 1px 4px; margin-left: 4px; }
-        .unarchived-badge { font-size: 10px; color: #d29922; border: 1px solid #d29922; border-radius: 3px; padding: 1px 4px; margin-left: 6px; }
-        .important-badge { font-size: 10px; color: #58a6ff; border: 1px solid #58a6ff; border-radius: 3px; padding: 1px 4px; margin-left: 6px; }
+        .chip { font-size: 10px; border: 1px solid; border-radius: 3px; padding: 1px 5px; margin-left: 6px; display: inline-block; }
         .status-text { white-space: pre-wrap; }
         .status-text.loading { color: #d29922; }
         .copy-prompt { cursor: pointer; color: #8b949e; font-size: 10px; position: relative; padding: 2px 8px; margin-right: 6px; font-family: inherit; display: inline-block; }
@@ -360,6 +411,7 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
         .update-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 199; }
         .period-select { background: #21262d; color: #c9d1d9; border: 1px solid #30363d; border-radius: 3px; padding: 2px 6px; font-family: inherit; font-size: 12px; margin-left: 8px; cursor: pointer; }
         .period-select:hover { border-color: #58a6ff; }
+        .sticky-header { position: sticky; top: 0; z-index: 100; background: #0d1117; padding-bottom: 0; }
         .nav-tabs { display: flex; gap: 0; margin-bottom: 16px; border-bottom: 1px solid #21262d; }
         .nav-tab { color: #8b949e; text-decoration: none; padding: 8px 16px; font-size: 13px; border-bottom: 2px solid transparent; cursor: pointer; }
         .nav-tab:hover { color: #c9d1d9; }
@@ -397,6 +449,7 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
         }
     </script>
     ${updateHtml}
+    <div class="sticky-header">
     <h1>
         GitHub Status - ${date}
         ${updateInfo && updateInfo.behind ? `<button class="update-btn" onclick="document.getElementById('update-overlay').style.display='block';document.getElementById('update-popup').style.display='block'">UPDATE AVAILABLE</button>` : ''}
@@ -413,6 +466,8 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
         <span class="nav-tab active" data-tab="prs" onclick="switchTab('prs')">Pull Requests</span>
         <span class="nav-tab" data-tab="issues" onclick="switchTab('issues')">Issues</span>
         <span class="nav-tab" data-tab="correspondence" onclick="switchTab('correspondence')">Correspondence (${totalCorrespondence})</span>
+        <span class="nav-tab" data-tab="checkouts" onclick="switchTab('checkouts')">Checkouts (${(checkoutItems || []).length})</span>
+    </div>
     </div>
     <div class="fold-controls"><a onclick="foldAll()">Fold all</a><a onclick="unfoldAll()">Unfold all</a></div>
 
@@ -580,6 +635,28 @@ ${commentedIssueRows}
 
     </div>
 
+    <div id="tab-checkouts" class="tab-panel">
+    <h1 class="section-heading">Local Checkouts</h1>
+
+    <h2 onclick="toggleFold(this)">Git Repositories (${(checkoutItems || []).length})</h2>
+    <table>
+        <thead>
+            <tr>
+                <th class="repo-col">Repo</th>
+                <th class="title-col">Title</th>
+                <th class="branch-col">Branch</th>
+                <th class="status-col">AI-Status</th>
+                <th class="ci-col">CI</th>
+                <th class="days-col">Days</th>
+            </tr>
+        </thead>
+        <tbody>
+${checkoutRows}
+        </tbody>
+    </table>
+    <hr class="subdivider">
+    </div>
+
     <p class="footer">Generated ${date}</p>
 
     <script>
@@ -636,6 +713,19 @@ ${commentedIssueRows}
         });
 
         const _clonePaths = {};
+        const CHIP_PALETTE = {
+            green:{color:'#3fb950',bg:'#1a3a1a',border:'#238636'},
+            yellow:{color:'#d29922',bg:'#3d1f00',border:'#9e6a03'},
+            blue:{color:'#58a6ff',bg:'#0c2d6b',border:'#1f6feb'},
+            red:{color:'#f85149',bg:'#3d0a0a',border:'#da3633'},
+            purple:{color:'#a371f7',bg:'#271c4d',border:'#8957e5'},
+            muted:{color:'#484f58',bg:'#161b22',border:'#30363d'},
+            grey:{color:'#8b949e',bg:'#1c2128',border:'#30363d'},
+        };
+        function makeChip(label, tone, extraClass) {
+            const p = CHIP_PALETTE[tone] || CHIP_PALETTE.grey;
+            return '<span class="chip' + (extraClass ? ' ' + extraClass : '') + '" style="color:' + p.color + ';background:' + p.bg + ';border-color:' + p.border + '">' + label + '</span>';
+        }
         function inlineChat(index) {
             fetch('/api/chat', {
                 method: 'POST',
@@ -655,6 +745,29 @@ ${commentedIssueRows}
             }).then(resp => resp.json()).then(data => {
                 if (data.error) throw new Error(data.error);
             });
+        }
+
+        function toHomePath(path) {
+            const parts = path.split('/');
+            return (parts[1] === 'home' || parts[1] === 'Users') ? '~/' + parts.slice(3).join('/') : path;
+        }
+        function renderCloneChips(clone) {
+            let html = '';
+            const count = clone.changedFiles ? clone.changedFiles.length : (clone.changedCount || 0);
+            if (clone.dirty) {
+                html += makeChip(count + ' changed', 'yellow');
+            } else {
+                html += makeChip('clean', 'green');
+            }
+            const divergeLabels = {ahead:['ahead of remote','blue'],behind:['behind remote','yellow'],diverged:['diverged','red'],'no-remote':['no remote','muted']};
+            const dl = divergeLabels[clone.divergeStatus];
+            if (dl) html += makeChip(dl[0], dl[1]);
+            return html;
+        }
+        for (const c of ${checkoutCloneData}) {
+            _clonePaths[c.idx] = c.path;
+            const bc = document.getElementById('branch-' + c.idx);
+            if (bc) bc.innerHTML += renderCloneChips(c);
         }
 
         function copyPrompt(index) {
@@ -816,10 +929,7 @@ ${commentedIssueRows}
                     row.setAttribute('data-marked-important', '1');
                     const titleCol = row.querySelector('.title-col');
                     if (titleCol && !titleCol.querySelector('.important-badge')) {
-                        const badge = document.createElement('span');
-                        badge.className = 'important-badge';
-                        badge.textContent = 'marked as important';
-                        titleCol.appendChild(badge);
+                        titleCol.insertAdjacentHTML('beforeend', makeChip('marked as important', 'blue', 'important-badge'));
                     }
                 },
             });
@@ -875,15 +985,24 @@ ${commentedIssueRows}
                 body: JSON.stringify({ index: scanIdx })
             }).then(resp => resp.json()).then(scan => {
                 if (scan.error) throw new Error(scan.error);
-                const match = (scan.clones || []).find(clone => clone.onPRBranch && !clone.behindOrigin && !clone.diverged);
+                if (_clonePaths[scanIdx]) return; // checkout item — already has clone info
+                const match = (scan.clones || []).find(clone => clone.onPRBranch && clone.divergeStatus !== 'behind' && clone.divergeStatus !== 'diverged');
                 if (!match) return;
                 _clonePaths[scanIdx] = match.path;
+                // Append clone path to title cell
+                const titleCell = document.getElementById('title-' + scanIdx);
+                if (titleCell) {
+                    titleCell.innerHTML += '<br><span class="clone-badge">' + toHomePath(match.path) + '</span>';
+                }
+                // Append dirty/diverge chips to branch cell
+                const branchCell = document.getElementById('branch-' + scanIdx);
+                if (branchCell) {
+                    branchCell.innerHTML += renderCloneChips(match);
+                }
+                // Add chat/IDE buttons to inline actions
                 const inlineEl = document.getElementById('inline-actions-' + scanIdx);
                 if (!inlineEl) return;
-                const parts = match.path.split('/');
-                const homePath = (parts[1] === 'home' || parts[1] === 'Users') ? '~/' + parts.slice(3).join('/') : match.path;
-                let html = '<span class="clone-badge">' + homePath + '</span>';
-                html += '<span class="inline-action" onclick="inlineChat(' + scanIdx + ')">chat</span>';
+                let html = '<span class="inline-action" onclick="inlineChat(' + scanIdx + ')">chat</span>';
                 const ides = (typeof INSTALLED_IDES !== 'undefined') ? INSTALLED_IDES : [];
                 for (const ide of ides) {
                     const cmd = ide.cmd.replaceAll('&','&amp;').replaceAll('"','&quot;');
@@ -920,12 +1039,7 @@ ${commentedIssueRows}
             if (branchCell) {
                 branchCell.classList.remove('status-loading');
                 const branch = data.branch;
-                let html = '<span class="branch-name" onclick="copyBranch(this)" title="Click to copy">' + branch.replaceAll('&','&amp;').replaceAll('<','&lt;') + '</span>';
-                if (branch) {
-                    const cmd = 'cd ~/' + data.repoShort + ' && git fetch origin ' + branch + ' && git checkout ' + branch;
-                    html += '<br><span class="checkout-cmd" onclick="copyCmd(this)" data-cmd="' + cmd.replaceAll('"','&quot;') + '">copy git checkout cmd</span>';
-                }
-                branchCell.innerHTML = html;
+                branchCell.innerHTML = '<span class="branch-name" onclick="copyBranch(this)" title="Click to copy">' + branch.replaceAll('&','&amp;').replaceAll('<','&lt;') + '</span>';
             }
             const ciCell = document.getElementById('ci-' + data.index);
             if (ciCell) {
@@ -941,6 +1055,28 @@ ${commentedIssueRows}
                 }
             }
             pendingScanQueue.push(data.index); drainScanQueue();
+            // Checkout items: prepend PR link to title, update chips with refined diverge status
+            if (data.prTitle) {
+                const titleCell = document.getElementById('title-' + data.index);
+                if (titleCell) {
+                    const stateTones = {open:'green',merged:'purple',closed:'red'};
+                    const prLink = '<a href="' + data.prUrl + '">#' + data.prNumber + ' ' + data.prTitle.replace(/&/g,'&amp;').replace(/</g,'&lt;') + '</a>'
+                        + (data.prState ? makeChip(data.prState, stateTones[data.prState] || 'grey') : '');
+                    titleCell.innerHTML = prLink + '<br>' + titleCell.innerHTML;
+                }
+                const daysCell = document.getElementById('days-' + data.index);
+                if (daysCell && data.prDays !== undefined) {
+                    daysCell.textContent = data.prDays + 'd';
+                    daysCell.className = 'days-col days-' + (data.prDays <= 3 ? 'good' : data.prDays <= 14 ? 'warning' : 'bad');
+                }
+            }
+            if (data.divergeStatus !== undefined) {
+                const branchCell = document.getElementById('branch-' + data.index);
+                if (branchCell) {
+                    branchCell.querySelectorAll('.chip').forEach(c => c.remove());
+                    branchCell.innerHTML += renderCloneChips(data);
+                }
+            }
         });
 
         onSSE(eventSource, 'ai-log', data => {
@@ -1022,10 +1158,7 @@ ${commentedIssueRows}
                 onRow: row => {
                     const titleCol = row.querySelector('.title-col');
                     if (titleCol && !titleCol.querySelector('.unarchived-badge')) {
-                        const badge = document.createElement('span');
-                        badge.className = 'unarchived-badge';
-                        badge.textContent = 'unarchived: new comments';
-                        titleCol.appendChild(badge);
+                        titleCol.insertAdjacentHTML('beforeend', makeChip('unarchived: new comments', 'yellow', 'unarchived-badge'));
                     }
                 },
             });

--- a/dashboard-html.js
+++ b/dashboard-html.js
@@ -125,6 +125,10 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
     grey:   { color: '#8b949e', bg: '#1c2128', border: '#30363d' },
   };
 
+  const stateTones = { open: 'green', merged: 'purple', closed: 'red' };
+
+  const divergeLabels = { ahead: ['ahead of remote', 'blue'], behind: ['behind remote', 'yellow'], diverged: ['diverged', 'red'], 'no-remote': ['no remote', 'muted'] };
+
   function chip(label, tone, extraClass) {
     const p = chipPalette[tone] || chipPalette.grey;
     return ` <span class="chip${extraClass ? ' ' + extraClass : ''}" style="color:${p.color};background:${p.bg};border-color:${p.border}">${label}</span>`;
@@ -132,8 +136,7 @@ export function buildDashboardHtml(myPRs, reviewPRs, assignedIssues, createdIssu
 
   function stateBadge(state) {
     if (!state) return '';
-    const tones = { open: 'green', merged: 'purple', closed: 'red' };
-    return chip(state, tones[state] || 'grey');
+    return chip(state, stateTones[state] || 'grey');
   }
 
   function statusCell(item, globalIndex, prefillActions) {
@@ -713,15 +716,9 @@ ${checkoutRows}
         });
 
         const _clonePaths = {};
-        const CHIP_PALETTE = {
-            green:{color:'#3fb950',bg:'#1a3a1a',border:'#238636'},
-            yellow:{color:'#d29922',bg:'#3d1f00',border:'#9e6a03'},
-            blue:{color:'#58a6ff',bg:'#0c2d6b',border:'#1f6feb'},
-            red:{color:'#f85149',bg:'#3d0a0a',border:'#da3633'},
-            purple:{color:'#a371f7',bg:'#271c4d',border:'#8957e5'},
-            muted:{color:'#484f58',bg:'#161b22',border:'#30363d'},
-            grey:{color:'#8b949e',bg:'#1c2128',border:'#30363d'},
-        };
+        const CHIP_PALETTE = ${JSON.stringify(chipPalette)};
+        const STATE_TONES = ${JSON.stringify(stateTones)};
+        const DIVERGE_LABELS = ${JSON.stringify(divergeLabels)};
         function makeChip(label, tone, extraClass) {
             const p = CHIP_PALETTE[tone] || CHIP_PALETTE.grey;
             return '<span class="chip' + (extraClass ? ' ' + extraClass : '') + '" style="color:' + p.color + ';background:' + p.bg + ';border-color:' + p.border + '">' + label + '</span>';
@@ -751,16 +748,16 @@ ${checkoutRows}
             const parts = path.split('/');
             return (parts[1] === 'home' || parts[1] === 'Users') ? '~/' + parts.slice(3).join('/') : path;
         }
-        function renderCloneChips(clone) {
+        function renderCloneChips(clone, opts) {
             let html = '';
             const count = clone.changedFiles ? clone.changedFiles.length : (clone.changedCount || 0);
             if (clone.dirty) {
-                html += makeChip(count + ' changed', 'yellow');
+                const label = opts && opts.dirtyLabel ? opts.dirtyLabel(count) : (count + ' changed');
+                html += makeChip(label, 'yellow');
             } else {
                 html += makeChip('clean', 'green');
             }
-            const divergeLabels = {ahead:['ahead of remote','blue'],behind:['behind remote','yellow'],diverged:['diverged','red'],'no-remote':['no remote','muted']};
-            const dl = divergeLabels[clone.divergeStatus];
+            const dl = DIVERGE_LABELS[clone.divergeStatus];
             if (dl) html += makeChip(dl[0], dl[1]);
             return html;
         }
@@ -1059,9 +1056,8 @@ ${checkoutRows}
             if (data.prTitle) {
                 const titleCell = document.getElementById('title-' + data.index);
                 if (titleCell) {
-                    const stateTones = {open:'green',merged:'purple',closed:'red'};
                     const prLink = '<a href="' + data.prUrl + '">#' + data.prNumber + ' ' + data.prTitle.replace(/&/g,'&amp;').replace(/</g,'&lt;') + '</a>'
-                        + (data.prState ? makeChip(data.prState, stateTones[data.prState] || 'grey') : '');
+                        + (data.prState ? makeChip(data.prState, STATE_TONES[data.prState] || 'grey') : '');
                     titleCell.innerHTML = prLink + '<br>' + titleCell.innerHTML;
                 }
                 const daysCell = document.getElementById('days-' + data.index);

--- a/public/repo-picker.js
+++ b/public/repo-picker.js
@@ -170,7 +170,7 @@ function renderRepoSelectionDialog(dlg, data, index) {
 }
 
 function renderCloneRow(clone, branch) {
-  const homePath = clone.path.replace(/^\/Users\/[^/]+/, '~').replace(/^\/home\/[^/]+/, '~');
+  const homePath = toHomePath(clone.path);
   let html = '<li class="dlg-clone-row" style="flex-wrap:wrap">';
 
   // Top line: path, branch, badges
@@ -179,18 +179,9 @@ function renderCloneRow(clone, branch) {
   if (clone.onPRBranch) {
     html += makeChip('on branch', 'blue');
   }
-  if (clone.dirty) {
-    html += makeChip('dirty: ' + clone.changedFiles.length + ' file' + (clone.changedFiles.length !== 1 ? 's' : ''), 'yellow');
-  } else {
-    html += makeChip('clean', 'green');
-  }
-  if (clone.divergeStatus === 'diverged') {
-    html += makeChip('diverged', 'red');
-  } else if (clone.divergeStatus === 'behind') {
-    html += makeChip('behind remote', 'yellow');
-  } else if (clone.divergeStatus === 'ahead') {
-    html += makeChip('ahead of remote', 'blue');
-  }
+  html += renderCloneChips(clone, {
+    dirtyLabel: count => 'dirty: ' + count + ' file' + (count !== 1 ? 's' : '')
+  });
 
   // Action buttons row
   html += '<div class="dlg-actions" style="width:100%;margin-top:4px">';

--- a/public/repo-picker.js
+++ b/public/repo-picker.js
@@ -16,12 +16,6 @@ function ensureStyles() {
 .dlg-clone-row:hover { background:#1c2128; }\
 .dlg-clone-path { flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#c9d1d9; }\
 .dlg-clone-branch { color:#8b949e;font-size:11px;white-space:nowrap; }\
-.dlg-badge { font-size:10px;padding:1px 6px;border-radius:3px;white-space:nowrap; }\
-.dlg-badge-clean { background:#1a3a1a;color:#3fb950;border:1px solid #238636; }\
-.dlg-badge-dirty { background:#3d1f00;color:#d29922;border:1px solid #9e6a03; }\
-.dlg-badge-branch { background:#0c2d6b;color:#58a6ff;border:1px solid #1f6feb; }\
-.dlg-badge-behind { background:#3d1f00;color:#d29922;border:1px solid #9e6a03; }\
-.dlg-badge-diverged { background:#3d0a0a;color:#f85149;border:1px solid #da3633; }\
 .dlg-actions { display:flex;gap:6px;flex-shrink:0; }\
 .dlg-btn { background:none;border:1px solid #30363d;color:#c9d1d9;padding:3px 10px;border-radius:4px;font-family:inherit;font-size:11px;cursor:pointer;white-space:nowrap; }\
 .dlg-btn:hover { border-color:#58a6ff;color:#58a6ff; }\
@@ -157,7 +151,7 @@ function renderRepoSelectionDialog(dlg, data, index) {
               tmp.innerHTML = renderCloneRow({
                 path: clonePath,
                 currentBranch: row.querySelector('.dlg-clone-branch').textContent.replace(/[()]/g, ''),
-                onPRBranch: true, dirty: false, changedFiles: [], diverged: true, behindOrigin: false
+                onPRBranch: true, dirty: false, changedFiles: [], divergeStatus: 'diverged'
               }, branchName);
               row.replaceWith(tmp.firstElementChild);
             }
@@ -183,31 +177,33 @@ function renderCloneRow(clone, branch) {
   html += '<span class="dlg-clone-path" title="' + esc(clone.path) + '">' + esc(homePath) + '</span>';
   html += '<span class="dlg-clone-branch">(' + esc(clone.currentBranch) + ')</span>';
   if (clone.onPRBranch) {
-    html += '<span class="dlg-badge dlg-badge-branch">on branch</span>';
+    html += makeChip('on branch', 'blue');
   }
   if (clone.dirty) {
-    html += '<span class="dlg-badge dlg-badge-dirty">dirty: ' + clone.changedFiles.length + ' file' + (clone.changedFiles.length !== 1 ? 's' : '') + '</span>';
+    html += makeChip('dirty: ' + clone.changedFiles.length + ' file' + (clone.changedFiles.length !== 1 ? 's' : ''), 'yellow');
   } else {
-    html += '<span class="dlg-badge dlg-badge-clean">clean</span>';
+    html += makeChip('clean', 'green');
   }
-  if (clone.diverged) {
-    html += '<span class="dlg-badge dlg-badge-diverged">diverged</span>';
-  } else if (clone.behindOrigin) {
-    html += '<span class="dlg-badge dlg-badge-behind">behind</span>';
+  if (clone.divergeStatus === 'diverged') {
+    html += makeChip('diverged', 'red');
+  } else if (clone.divergeStatus === 'behind') {
+    html += makeChip('behind remote', 'yellow');
+  } else if (clone.divergeStatus === 'ahead') {
+    html += makeChip('ahead of remote', 'blue');
   }
 
   // Action buttons row
   html += '<div class="dlg-actions" style="width:100%;margin-top:4px">';
-  if (clone.diverged) {
+  if (clone.divergeStatus === 'diverged') {
     html += '<span style="color:#f85149;font-size:10px">Local and remote branches are diverged \u2014 resolve manually</span>';
-  } else if (clone.dirty && (clone.behindOrigin || !clone.onPRBranch)) {
+  } else if (clone.dirty && (clone.divergeStatus === 'behind' || !clone.onPRBranch)) {
     html += '<span style="color:#f85149;font-size:10px">dirty \u2014 commit or stash first</span>';
-  } else if (clone.behindOrigin || !clone.onPRBranch) {
+  } else if (clone.divergeStatus === 'behind' || !clone.onPRBranch) {
     const syncLabel = !clone.onPRBranch ? 'Checkout branch' : 'Pull latest';
     const syncAction = !clone.onPRBranch ? 'checkout' : 'pull';
     html += '<button class="dlg-btn dlg-btn-primary" data-sync="' + syncAction + '" data-clone="' + esc(clone.path) + '" data-branch="' + esc(branch || '') + '">' + syncLabel + '</button>';
   } else {
-    html += '<span class="dlg-badge dlg-badge-clean">ready</span>';
+    html += makeChip('ready', 'green');
   }
   html += '</div>';
 
@@ -226,17 +222,30 @@ function updateInlineActions(index, clonePath) {
       if (key !== String(index) && _clonePaths[key] === clonePath) {
         const staleEl = document.getElementById('inline-actions-' + key);
         if (staleEl) staleEl.innerHTML = '';
+        // Also clear title path and branch chips for stale items
+        const staleTitle = document.getElementById('title-' + key);
+        if (staleTitle) { const cb = staleTitle.querySelector('.clone-badge'); if (cb) { cb.previousSibling?.remove(); cb.remove(); } }
+        const staleBranch = document.getElementById('branch-' + key);
+        if (staleBranch) staleBranch.querySelectorAll('.chip').forEach(c => c.remove());
         delete _clonePaths[key];
       }
     }
     _clonePaths[index] = clonePath;
   }
+  // Append clone path to title cell
+  const titleCell = document.getElementById('title-' + index);
+  if (titleCell && !titleCell.querySelector('.clone-badge')) {
+    titleCell.innerHTML += '<br><span class="clone-badge">' + esc(toHomePath(clonePath)) + '</span>';
+  }
+  // Append clean chip to branch cell (just synced/cloned)
+  const branchCell = document.getElementById('branch-' + index);
+  if (branchCell && !branchCell.querySelector('.chip')) {
+    branchCell.innerHTML += makeChip('clean', 'green');
+  }
+  // Add chat/IDE buttons to inline actions
   const inlineEl = document.getElementById('inline-actions-' + index);
   if (!inlineEl) return;
-  const parts = clonePath.split('/');
-  const homePath = (parts[1] === 'home' || parts[1] === 'Users') ? '~/' + parts.slice(3).join('/') : clonePath;
-  let html = '<span class="clone-badge">' + esc(homePath) + '</span>';
-  html += '<span class="inline-action" onclick="inlineChat(' + index + ')">chat</span>';
+  let html = '<span class="inline-action" onclick="inlineChat(' + index + ')">chat</span>';
   const ides = (typeof INSTALLED_IDES !== 'undefined') ? INSTALLED_IDES : [];
   for (const ide of ides) {
     const cmd = ide.cmd.replaceAll('&','&amp;').replaceAll('"','&quot;');

--- a/repo-scan.js
+++ b/repo-scan.js
@@ -117,14 +117,20 @@ export async function buildCloneIndex(log) {
     const status = await runCmd('git', ['status', '--porcelain'], { cwd: dir, reason: `dirty check: ${remoteRepo}` });
     const dirty = !!status;
     const changedFiles = status ? status.split('\n') : [];
-    return { remoteRepo, dir, currentBranch, dirty, changedFiles };
+    // Store raw refs for lazy divergence check later (no git commands here)
+    let localHead = null, trackingHead = null;
+    if (currentBranch) {
+      localHead = readRef(gitDir, `refs/heads/${currentBranch}`);
+      trackingHead = readRef(gitDir, `refs/remotes/origin/${currentBranch}`);
+    }
+    return { remoteRepo, dir, currentBranch, dirty, changedFiles, localHead, trackingHead };
   }));
 
   const index = new Map();
-  for (const { remoteRepo, dir, currentBranch, dirty, changedFiles } of results) {
+  for (const { remoteRepo, dir, currentBranch, dirty, changedFiles, localHead, trackingHead } of results) {
     const key = remoteRepo.toLowerCase();
     if (!index.has(key)) index.set(key, []);
-    index.get(key).push({ path: dir, currentBranch, dirty, changedFiles });
+    index.get(key).push({ path: dir, currentBranch, dirty, changedFiles, localHead, trackingHead });
   }
 
   const summary = `Clone index: ${gitDirs.length} repos scanned, ${index.size} unique remotes`;
@@ -135,7 +141,7 @@ export async function buildCloneIndex(log) {
 
 /**
  * Look up clones for a repo from the pre-built index.
- * Derives branch-specific fields (onPRBranch, behindOrigin, etc.) from stored refs.
+ * Derives branch-specific fields (onPRBranch, divergeStatus, etc.) from stored refs.
  */
 export async function scanForClones(repo, branch, headSha, index) {
   const home = homedir();
@@ -151,10 +157,11 @@ export async function scanForClones(repo, branch, headSha, index) {
 
     // Use headSha for divergence check, fall back to tracking ref if it doesn't exist locally.
     // If neither works but API says remote differs, assume behind (pull will do the real check).
-    const divergeStatus = await checkDivergence(clone.path, localHead, remoteHead)
+    let divergeStatus = await checkDivergence(clone.path, localHead, remoteHead)
       ?? await checkDivergence(clone.path, localHead, trackingHead);
-    const behindOrigin = divergeStatus === 'behind' || (divergeStatus === null && localHead && remoteHead && localHead !== remoteHead);
-    const diverged = divergeStatus === 'diverged';
+    if (!divergeStatus && localHead && remoteHead && localHead !== remoteHead) {
+      divergeStatus = 'behind';
+    }
 
     return {
       path: clone.path,
@@ -163,8 +170,7 @@ export async function scanForClones(repo, branch, headSha, index) {
       dirty: clone.dirty,
       changedFiles: clone.changedFiles,
       hasBranchLocally,
-      behindOrigin,
-      diverged,
+      divergeStatus,
       localHead,
       remoteHead,
     };

--- a/server.js
+++ b/server.js
@@ -256,6 +256,35 @@ async function handleStatusStream(req, res) {
     const allItems = [...allPRs, ...allIssues, ...allCorrespondence];
     pendingPRData = allItems;
 
+    // Add all local checkouts to allItems for async PR discovery in Phase 2
+    const defaultBranches = new Set(['main', 'master', 'develop', 'development']);
+    if (cloneIdx) {
+      const checkoutEntries = [];
+      for (const [repoKey, clones] of cloneIdx) {
+        for (const clone of clones) {
+          checkoutEntries.push({
+            repo: repoKey,
+            title: '',
+            html_url: '',
+            number: 0,
+            updated_at: new Date().toISOString(),
+            section: 'checkout',
+            days: 0,
+            isIssue: false,
+            _checkoutPath: clone.path,
+            _checkoutDisplayPath: clone.path.startsWith(home) ? '~' + clone.path.slice(home.length) : clone.path,
+            _checkoutBranch: clone.currentBranch,
+            _checkoutDirty: clone.dirty,
+            _checkoutChangedFiles: clone.changedFiles.length,
+            _checkoutSkipAI: !clone.currentBranch || defaultBranches.has(clone.currentBranch),
+            _checkoutDivergeStatus: !clone.trackingHead ? 'no-remote' : clone.localHead === clone.trackingHead ? 'synced' : null,
+          });
+        }
+      }
+      checkoutEntries.sort((a, b) => a.repo.localeCompare(b.repo) || a._checkoutPath.localeCompare(b._checkoutPath));
+      allItems.push(...checkoutEntries);
+    }
+
     // Update persistent repo color assignments
     const allRepoNames = [...new Set(allItems.map(item => item.repo.split('/').pop()))];
     repoColorMap = updateRepoColors(allRepoNames);
@@ -272,7 +301,8 @@ async function handleStatusStream(req, res) {
     const autoUnarchivedUrls = readAutoUnarchived();
     const unimportantUrls = readUnimportant();
     const markedImportantUrls = readMarkedImportant();
-    const html = buildDashboardHtml(myPRsForHtml, reviewPRsForHtml, assignedIssuesForHtml, createdIssuesForHtml, mentionedPRsForHtml, commentedPRsForHtml, mentionedIssuesForHtml, commentedIssuesForHtml, date, updateInfo, { repoColorMap, installedIDEs, period, ghUsername, archivedUrls, autoUnarchivedUrls, unimportantUrls, markedImportantUrls });
+    const checkoutItems = allItems.filter(item => item.section === 'checkout');
+    const html = buildDashboardHtml(myPRsForHtml, reviewPRsForHtml, assignedIssuesForHtml, createdIssuesForHtml, mentionedPRsForHtml, commentedPRsForHtml, mentionedIssuesForHtml, commentedIssuesForHtml, date, updateInfo, { repoColorMap, installedIDEs, period, ghUsername, archivedUrls, autoUnarchivedUrls, unimportantUrls, markedImportantUrls, checkoutItems });
 
     setCmdLogHook(null);
     const cmdLog = getCommandLog();
@@ -353,18 +383,49 @@ const server = http.createServer((req, res) => {
       const pr = pendingPRData && pendingPRData[index];
       if (!pr) { res.writeHead(404); res.end(JSON.stringify({ error: 'Item not found. Reload the page.' })); return; }
 
-      await launchChat({
-        prompt: pr.chatContext || '',
-        url: pr.html_url,
-        repo: pr.repo,
-        number: pr.number,
-        title: pr.title,
-        isIssue: pr.isIssue,
-        branch: pr.details?.headRefName || '',
-        aiStatus: pr.aiStatus || '',
-        action: action || 'chat-here',
-        clonePath: clonePath || '',
-      });
+      if (pr.section === 'checkout') {
+        const checkoutPath = clonePath || pr._checkoutPath;
+        const branch = (await runCmd('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: checkoutPath })).trim();
+        const defaultBranch = await runCmd('git', ['rev-parse', '--verify', 'refs/heads/main'], { cwd: checkoutPath }).then(() => 'main').catch(() =>
+          runCmd('git', ['rev-parse', '--verify', 'refs/heads/master'], { cwd: checkoutPath }).then(() => 'master').catch(() => null)
+        );
+        let diff = '';
+        if (defaultBranch && branch !== defaultBranch) {
+          const mergeBase = (await runCmd('git', ['merge-base', defaultBranch, 'HEAD'], { cwd: checkoutPath })).trim();
+          diff = await runCmd('git', ['diff', mergeBase, 'HEAD'], { cwd: checkoutPath });
+          if (diff.length > 20000) diff = diff.slice(0, 20000) + '\n... (truncated)';
+        } else {
+          diff = '(on default branch, no diff)';
+        }
+        const originUrl = (await runCmd('git', ['remote', 'get-url', 'origin'], { cwd: checkoutPath }).catch(() => '')).trim();
+        const repoMatch = originUrl.match(/[:\/]([^/]+\/[^/]+?)(?:\.git)?$/);
+        const repo = repoMatch ? repoMatch[1] : 'unknown';
+        await launchChat({
+          prompt: `## Diff against ${defaultBranch || 'default branch'} (merge-base)\n\n\`\`\`diff\n${diff}\n\`\`\``,
+          url: '',
+          repo,
+          number: 0,
+          title: `${branch} in ${repo.split('/').pop()}`,
+          isIssue: false,
+          branch,
+          aiStatus: '',
+          action: action || 'chat-here',
+          clonePath: checkoutPath,
+        });
+      } else {
+        await launchChat({
+          prompt: pr.chatContext || '',
+          url: pr.html_url,
+          repo: pr.repo,
+          number: pr.number,
+          title: pr.title,
+          isIssue: pr.isIssue,
+          branch: pr.details?.headRefName || '',
+          aiStatus: pr.aiStatus || '',
+          action: action || 'chat-here',
+          clonePath: clonePath || '',
+        });
+      }
 
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end('{"ok":true}');

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ const PORT = process.env.PORT || 7777;
 const DATA_DIR = join(PROJECT_DIR, 'data');
 const PERIOD_FILE = join(DATA_DIR, 'period.json');
 const VALID_PERIODS = ['7d', '30d', '90d', 'all'];
+const DEFAULT_BRANCHES = ['main', 'master', 'develop', 'development'];
 
 function readPeriod() {
   if (existsSync(PERIOD_FILE)) {
@@ -257,7 +258,7 @@ async function handleStatusStream(req, res) {
     pendingPRData = allItems;
 
     // Add all local checkouts to allItems for async PR discovery in Phase 2
-    const defaultBranches = new Set(['main', 'master', 'develop', 'development']);
+    const defaultBranchSet = new Set(DEFAULT_BRANCHES);
     if (cloneIdx) {
       const checkoutEntries = [];
       for (const [repoKey, clones] of cloneIdx) {
@@ -276,7 +277,7 @@ async function handleStatusStream(req, res) {
             _checkoutBranch: clone.currentBranch,
             _checkoutDirty: clone.dirty,
             _checkoutChangedFiles: clone.changedFiles.length,
-            _checkoutSkipAI: !clone.currentBranch || defaultBranches.has(clone.currentBranch),
+            _checkoutSkipAI: !clone.currentBranch || defaultBranchSet.has(clone.currentBranch),
             _checkoutDivergeStatus: !clone.trackingHead ? 'no-remote' : clone.localHead === clone.trackingHead ? 'synced' : null,
           });
         }
@@ -386,9 +387,11 @@ const server = http.createServer((req, res) => {
       if (pr.section === 'checkout') {
         const checkoutPath = clonePath || pr._checkoutPath;
         const branch = (await runCmd('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: checkoutPath })).trim();
-        const defaultBranch = await runCmd('git', ['rev-parse', '--verify', 'refs/heads/main'], { cwd: checkoutPath }).then(() => 'main').catch(() =>
-          runCmd('git', ['rev-parse', '--verify', 'refs/heads/master'], { cwd: checkoutPath }).then(() => 'master').catch(() => null)
-        );
+        let defaultBranch = null;
+        for (const name of DEFAULT_BRANCHES) {
+          const exists = await runCmd('git', ['rev-parse', '--verify', `refs/heads/${name}`], { cwd: checkoutPath }).then(() => true).catch(() => false);
+          if (exists) { defaultBranch = name; break; }
+        }
         let diff = '';
         if (defaultBranch && branch !== defaultBranch) {
           const mergeBase = (await runCmd('git', ['merge-base', defaultBranch, 'HEAD'], { cwd: checkoutPath })).trim();
@@ -397,9 +400,7 @@ const server = http.createServer((req, res) => {
         } else {
           diff = '(on default branch, no diff)';
         }
-        const originUrl = (await runCmd('git', ['remote', 'get-url', 'origin'], { cwd: checkoutPath }).catch(() => '')).trim();
-        const repoMatch = originUrl.match(/[:\/]([^/]+\/[^/]+?)(?:\.git)?$/);
-        const repo = repoMatch ? repoMatch[1] : 'unknown';
+        const repo = pr.repo;
         await launchChat({
           prompt: `## Diff against ${defaultBranch || 'default branch'} (merge-base)\n\n\`\`\`diff\n${diff}\n\`\`\``,
           url: '',


### PR DESCRIPTION
- New tab lists all local git checkouts with async PR discovery
- Shows dirty/clean, ahead/behind/diverged chips per branch
- Chat button launches Claude with merge-base diff context
- IDE buttons on all checkout rows
- Sticky header with nav tabs
- Rename "pick git clone" to "checkout"
- Remove "copy git checkout cmd" from branch column